### PR TITLE
Fix deprecated permission test

### DIFF
--- a/git-hooks
+++ b/git-hooks
@@ -43,7 +43,7 @@ function hook_dirs
 
 function list_hooks_in_dir
 {
-    find -L "${1}/" -perm +111 -type f 2>/dev/null | grep -v "^.$" | sort
+    find -L "${1}/" -perm /111 -type f 2>/dev/null | grep -v "^.$" | sort
 }
 
 function run_hooks


### PR DESCRIPTION
As described in find man page [1], -perm +mode is deprecated and -perm /mode should be used instead.

[1] http://man7.org/linux/man-pages/man1/find.1.html#EXPRESSIONS
