### PR TITLE
if user, project or global hooks are managed in a separate git (git s…

### DIFF
--- a/git-hooks
+++ b/git-hooks
@@ -43,7 +43,7 @@ function hook_dirs
 
 function list_hooks_in_dir
 {
-    find -L "${1}/" -perm +111 -type f 2>/dev/null | grep -v "^.$" | sort
+    find -L "${1}/" -perm +111 -type f 2>/dev/null | grep -v '/\.git/' | grep -v "^.$" | sort
 }
 
 function run_hooks


### PR DESCRIPTION
…ubmodule), we need to exclude the .git folder
